### PR TITLE
Update galaxy.xsd

### DIFF
--- a/galaxy.xsd
+++ b/galaxy.xsd
@@ -2331,6 +2331,7 @@ allow access to Python code to generate options for a select list. See
       <xs:enumeration value="select"/>
       <xs:enumeration value="data_column"/>
       <xs:enumeration value="hidden"/>
+      <xs:enumeration value="hidden_data"/>
       <xs:enumeration value="baseurl"/>
       <xs:enumeration value="file"/>
       <xs:enumeration value="data"/>


### PR DESCRIPTION
Add `hidden_data` in `ParamType`

The context [cufflinks](https://github.com/galaxyproject/tools-devteam/blob/master/tool_collections/cufflinks/cufflinks/cufflinks_wrapper.xml#L142)
`planemo lint .`
```
Applying linter tool_xsd... FAIL
.. ERROR: Invalid tmpw5U2MV found. Errors [/tmp/tmpw5U2MV:144:0:ERROR:SCHEMASV:SCHEMAV_CVC_ENUMERATION_VALID: Element 'param', attribute 'type': [facet 'enumeration'] The value 'hidden_data' is not an element of the set {'text', 'integer', 'float', 'color', 'boolean', 'genomebuild', 'library_data', 'select', 'data_column', 'hidden', 'baseurl', 'file', 'data', 'drill_down', 'data_collection'}.
/tmp/tmpw5U2MV:144:0:ERROR:SCHEMASV:SCHEMAV_CVC_DATATYPE_VALID_1_2_1: Element 'param', attribute 'type': 'hidden_data' is not a valid value of the atomic type 'ParamType'.
```
I don’t know so much this tag `hidden_data`, but it seems that it’s still in the [Galaxy doc](https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-inputs-param) 